### PR TITLE
Make composer outdated empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - php: 5.5
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.0
-      env: COMPOSER_FLAGS="" SYMFONY_VERSION="3.0.*"
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="3.2.*"
 
 before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/finder":      "^2.7|^3.0",
         "symfony/twig-bundle": "^2.7|^3.0",
         "symfony/yaml":        "^2.7|^3.0",
-        "twig/twig":           "^1.23.1"
+        "twig/twig":           "^1.23.1|^2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable":     true,

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,10 @@
         "symfony/http-kernel":          "^2.7|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit":     "^4.7|^5.0",
+        "phpunit/phpunit":     "^4.8.35|^6.0",
         "symfony/finder":      "^2.7|^3.0",
         "symfony/twig-bundle": "^2.7|^3.0",
+        "symfony/yaml":        "^2.7|^3.0",
         "twig/twig":           "^1.23.1"
     },
     "minimum-stability": "dev",

--- a/test/DependencyInjection/Compiler/FeaturesCompilerPassTest.php
+++ b/test/DependencyInjection/Compiler/FeaturesCompilerPassTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Yannickl88\FeaturesBundle\DependencyInjection\Compiler;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -11,7 +12,7 @@ use Yannickl88\FeaturesBundle\Feature\FeatureResolverInterface;
 /**
  * @covers Yannickl88\FeaturesBundle\DependencyInjection\Compiler\FeaturesCompilerPass
  */
-class FeaturesCompilerPassTest extends \PHPUnit_Framework_TestCase
+class FeaturesCompilerPassTest extends TestCase
 {
     /**
      * @var FeaturesCompilerPass

--- a/test/DependencyInjection/FeaturesExtensionTest.php
+++ b/test/DependencyInjection/FeaturesExtensionTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace Yannickl88\FeaturesBundle\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @covers Yannickl88\FeaturesBundle\DependencyInjection\FeaturesExtension
  * @covers Yannickl88\FeaturesBundle\DependencyInjection\Configuration
  */
-class FeaturesExtensionTest extends \PHPUnit_Framework_TestCase
+class FeaturesExtensionTest extends TestCase
 {
     /**
      * @var FeaturesExtension

--- a/test/Feature/ChainFeatureResolverTest.php
+++ b/test/Feature/ChainFeatureResolverTest.php
@@ -1,12 +1,13 @@
 <?php
 namespace Yannickl88\FeaturesBundle\Feature;
 
+use PHPUnit\Framework\TestCase;
 use Yannickl88\FeaturesBundle\Feature\FeatureContainerInterface;
 
 /**
  * @covers Yannickl88\FeaturesBundle\Feature\ChainFeatureResolver
  */
-class ChainFeatureResolverTest extends \PHPUnit_Framework_TestCase
+class ChainFeatureResolverTest extends TestCase
 {
     private $feature_container;
 

--- a/test/Feature/DeprecatedFeatureTest.php
+++ b/test/Feature/DeprecatedFeatureTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Yannickl88\FeaturesBundle\Feature;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Yannickl88\FeaturesBundle\Feature\DeprecatedFeature
  */
-class DeprecatedFeatureTest extends \PHPUnit_Framework_TestCase
+class DeprecatedFeatureTest extends TestCase
 {
     /**
      * @var DeprecatedFeature

--- a/test/Feature/Exception/FeatureNotFoundExceptionTest.php
+++ b/test/Feature/Exception/FeatureNotFoundExceptionTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Yannickl88\FeaturesBundle\Feature\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Yannickl88\FeaturesBundle\Feature\Exception\FeatureNotFoundException
  */
-class FeatureNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class FeatureNotFoundExceptionTest extends TestCase
 {
     public function testConstruct()
     {

--- a/test/Feature/Exception/ResolverNotFoundExceptionTest.php
+++ b/test/Feature/Exception/ResolverNotFoundExceptionTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Yannickl88\FeaturesBundle\Feature\Exception;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Yannickl88\FeaturesBundle\Feature\Exception\ResolverNotFoundException
  */
-class ResolverNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ResolverNotFoundExceptionTest extends TestCase
 {
     public function testConstruct()
     {

--- a/test/Feature/FeatureContainerTest.php
+++ b/test/Feature/FeatureContainerTest.php
@@ -1,12 +1,13 @@
 <?php
 namespace Yannickl88\FeaturesBundle\Feature;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @covers Yannickl88\FeaturesBundle\Feature\FeatureContainer
  */
-class FeatureContainerTest extends \PHPUnit_Framework_TestCase
+class FeatureContainerTest extends TestCase
 {
     private $container;
     private $feature;

--- a/test/Feature/FeatureFactoryTest.php
+++ b/test/Feature/FeatureFactoryTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Yannickl88\FeaturesBundle\Feature;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Yannickl88\FeaturesBundle\Feature\FeatureFactory
  */
-class FeatureFactoryTest extends \PHPUnit_Framework_TestCase
+class FeatureFactoryTest extends TestCase
 {
     private $feature_container;
 

--- a/test/Feature/ResolvableFeatureTest.php
+++ b/test/Feature/ResolvableFeatureTest.php
@@ -1,12 +1,13 @@
 <?php
 namespace Yannickl88\FeaturesBundle\Feature;
 
+use PHPUnit\Framework\TestCase;
 use Yannickl88\FeaturesBundle\Feature\Resolver;
 
 /**
  * @covers Yannickl88\FeaturesBundle\Feature\ResolvableFeature
  */
-class ResolvableFeatureTest extends \PHPUnit_Framework_TestCase
+class ResolvableFeatureTest extends TestCase
 {
     private $name;
     private $resolver;

--- a/test/Feature/ResolverTest.php
+++ b/test/Feature/ResolverTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Yannickl88\FeaturesBundle\Feature;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Yannickl88\FeaturesBundle\Feature\Resolver
  */
-class ResolverTest extends \PHPUnit_Framework_TestCase
+class ResolverTest extends TestCase
 {
     /**
      * @var Resolver

--- a/test/FeaturesBundleTest.php
+++ b/test/FeaturesBundleTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace Yannickl88\FeaturesBundle;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Yannickl88\FeaturesBundle\DependencyInjection\Compiler\FeaturesCompilerPass;
 
 /**
  * @covers Yannickl88\FeaturesBundle\FeaturesBundle
  */
-class FeaturesBundleTest extends \PHPUnit_Framework_TestCase
+class FeaturesBundleTest extends TestCase
 {
     /**
      * @var FeaturesBundle

--- a/test/Twig/FeaturesExtensionTest.php
+++ b/test/Twig/FeaturesExtensionTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace Yannickl88\FeaturesBundle\Twig;
 
+use PHPUnit\Framework\TestCase;
 use Yannickl88\FeaturesBundle\Feature\Feature;
 use Yannickl88\FeaturesBundle\Feature\FeatureContainerInterface;
 
 /**
  * @covers Yannickl88\FeaturesBundle\Twig\FeaturesExtension
  */
-class FeaturesExtensionTest extends \PHPUnit_Framework_TestCase
+class FeaturesExtensionTest extends TestCase
 {
     private $feature_container;
 


### PR DESCRIPTION
Let's try to allow Twig 2, see if the build still passes.