### PR TITLE
Added autowire support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # PHPUnit
 /phpunit.xml
 coverage/
-test/Functional/Fixtures/cache/
+/var/
 
 # composer
 /vendor/

--- a/src/DependencyInjection/Compiler/FeaturesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FeaturesCompilerPass.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 use Yannickl88\FeaturesBundle\Feature\Feature;
+use Yannickl88\FeaturesBundle\Feature\FeatureContainer;
 
 /**
  * Compiler pass which create the feature tag services and replaces the tagged
@@ -63,7 +64,7 @@ final class FeaturesCompilerPass implements CompilerPassInterface
             }
         }
         $container
-            ->getDefinition('features.container')
+            ->getDefinition(FeatureContainer::class)
             ->replaceArgument(2, $resolvers);
 
         return $resolvers;
@@ -104,7 +105,7 @@ final class FeaturesCompilerPass implements CompilerPassInterface
         }
 
         $container
-            ->getDefinition('features.container')
+            ->getDefinition(FeatureContainer::class)
             ->replaceArgument(1, $all);
 
         return $tags;

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,24 +1,27 @@
 services:
-    features.factory:
-        class: Yannickl88\FeaturesBundle\Feature\FeatureFactory
-        arguments:
-            - "@features.container"
+    # old service names, deprecated
+    features.factory: '@Yannickl88\FeaturesBundle\Feature\FeatureFactory'
+    features.container: '@Yannickl88\FeaturesBundle\Feature\FeatureContainer'
+    features.tag: '@Yannickl88\FeaturesBundle\Feature\DeprecatedFeature'
+    features.twig_extension: '@Yannickl88\FeaturesBundle\Twig\FeaturesExtension'
 
-    features.container:
-        class: Yannickl88\FeaturesBundle\Feature\FeatureContainer
+    Yannickl88\FeaturesBundle\Feature\FeatureFactory:
+        - '@Yannickl88\FeaturesBundle\Feature\FeatureContainer'
+
+    Yannickl88\FeaturesBundle\Feature\FeatureContainer:
         public: true
         arguments:
             - "@service_container"
             - [] # replaced by extension
             - [] # replaced by extension
 
-    features.tag:
-        class: Yannickl88\FeaturesBundle\Feature\DeprecatedFeature
+    # alias to allow autowiring the deprecated feature by default
+    Yannickl88\FeaturesBundle\Feature\Feature: '@Yannickl88\FeaturesBundle\Feature\DeprecatedFeature'
+    Yannickl88\FeaturesBundle\Feature\DeprecatedFeature: ~
 
-    features.twig_extension:
-        class: Yannickl88\FeaturesBundle\Twig\FeaturesExtension
+    Yannickl88\FeaturesBundle\Twig\FeaturesExtension:
         public: false
         arguments:
-            - "@features.container"
+            - '@Yannickl88\FeaturesBundle\Feature\FeatureContainer'
         tags:
-            - { name: twig.extension }
+            - twig.extension

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,7 +1,9 @@
 services:
     # old service names, deprecated
     features.factory: '@Yannickl88\FeaturesBundle\Feature\FeatureFactory'
-    features.container: '@Yannickl88\FeaturesBundle\Feature\FeatureContainer'
+    features.container:
+        alias: Yannickl88\FeaturesBundle\Feature\FeatureContainer
+        public: true
     features.tag: '@Yannickl88\FeaturesBundle\Feature\DeprecatedFeature'
     features.twig_extension: '@Yannickl88\FeaturesBundle\Twig\FeaturesExtension'
 

--- a/test/DependencyInjection/Compiler/FeaturesCompilerPassTest.php
+++ b/test/DependencyInjection/Compiler/FeaturesCompilerPassTest.php
@@ -10,7 +10,7 @@ use Yannickl88\FeaturesBundle\Feature\FeatureFactory;
 use Yannickl88\FeaturesBundle\Feature\FeatureResolverInterface;
 
 /**
- * @covers Yannickl88\FeaturesBundle\DependencyInjection\Compiler\FeaturesCompilerPass
+ * @covers \Yannickl88\FeaturesBundle\DependencyInjection\Compiler\FeaturesCompilerPass
  */
 class FeaturesCompilerPassTest extends TestCase
 {
@@ -50,8 +50,8 @@ class FeaturesCompilerPassTest extends TestCase
         $container->setDefinition('test.resolver1', $resolver1);
         $container->setDefinition('test.resolver2', $resolver2);
 
-        $container->setDefinition('features.factory', $factory);
-        $container->setDefinition('features.container', $feature_container);
+        $container->setDefinition(FeatureFactory::class, $factory);
+        $container->setDefinition(FeatureContainer::class, $feature_container);
         $container->setParameter('features.tags', ['foo' => 'foo', 'bar' => 'bar']);
         $container->setParameter('features.tags.foo.options', ['resolver1' => []]);
         $container->setParameter('features.tags.bar.options', ['resolver2' => []]);
@@ -81,7 +81,7 @@ class FeaturesCompilerPassTest extends TestCase
 
         $container->setDefinition('test.resolver', $resolver);
 
-        $container->setDefinition('features.factory', $factory);
+        $container->setDefinition(FeatureFactory::class, $factory);
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 
@@ -109,7 +109,7 @@ class FeaturesCompilerPassTest extends TestCase
         $container->setDefinition('test.resolver1', $resolver1);
         $container->setDefinition('test.resolver2', $resolver1);
 
-        $container->setDefinition('features.factory', $factory);
+        $container->setDefinition(FeatureFactory::class, $factory);
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 
@@ -136,8 +136,8 @@ class FeaturesCompilerPassTest extends TestCase
 
         $container->setDefinition('test.resolver', $resolver);
 
-        $container->setDefinition('features.factory', $factory);
-        $container->setDefinition('features.container', $feature_container);
+        $container->setDefinition(FeatureFactory::class, $factory);
+        $container->setDefinition(FeatureContainer::class, $feature_container);
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['missing' => []]);
 
@@ -171,8 +171,8 @@ class FeaturesCompilerPassTest extends TestCase
 
         $container->setDefinition('test.resolver', $resolver);
 
-        $container->setDefinition('features.factory', $factory);
-        $container->setDefinition('features.container', $feature_container);
+        $container->setDefinition(FeatureFactory::class, $factory);
+        $container->setDefinition(FeatureContainer::class, $feature_container);
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 
@@ -207,8 +207,8 @@ class FeaturesCompilerPassTest extends TestCase
 
         $container->setDefinition('test.resolver', $resolver);
 
-        $container->setDefinition('features.factory', $factory);
-        $container->setDefinition('features.container', $feature_container);
+        $container->setDefinition(FeatureFactory::class, $factory);
+        $container->setDefinition(FeatureContainer::class, $feature_container);
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 
@@ -242,8 +242,8 @@ class FeaturesCompilerPassTest extends TestCase
 
         $container->setDefinition('test.resolver', $resolver);
 
-        $container->setDefinition('features.factory', $factory);
-        $container->setDefinition('features.container', $feature_container);
+        $container->setDefinition(FeatureFactory::class, $factory);
+        $container->setDefinition(FeatureContainer::class, $feature_container);
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 

--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -19,4 +19,14 @@ class TestKernel extends Kernel
     {
         $loader->load(__DIR__ . '/config/config.yml');
     }
+
+    public function getLogDir()
+    {
+        return __DIR__ . '/../../../var/log';
+    }
+
+    public function getCacheDir()
+    {
+        return __DIR__ . '/../../../var/cache';
+    }
 }


### PR DESCRIPTION
 - Service ids are now the class name by default. 
 - Added an alias for the DeprecatedFeature so autowiring can pick it up based on the interface.
 - Log/cache dir of the functional testing kernel are now in the root dir.