### PR TITLE
Add service alias for the FeatureContainerInterface

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -10,6 +10,7 @@ services:
     Yannickl88\FeaturesBundle\Feature\FeatureFactory:
         - '@Yannickl88\FeaturesBundle\Feature\FeatureContainer'
 
+    Yannickl88\FeaturesBundle\Feature\FeatureContainerInterface: '@Yannickl88\FeaturesBundle\Feature\FeatureContainer'
     Yannickl88\FeaturesBundle\Feature\FeatureContainer:
         public: true
         arguments:


### PR DESCRIPTION
Currently, you can't autowire the FeatureContainerInterface.
Added the service alias from FeatureContainerInterface to its concrete
implementation FeatureContainer, which is a sane default that allows us
to write more flexible code