### PR TITLE
Remove support for old functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,22 +10,18 @@ env:
   - COMPOSER_FLAGS="--prefer-stable"
 
 php:
-    - 5.5.9
-    - 7.0
-    - 7.1
+    - 7.2
 
 matrix:
   include:
-    - php: 5.5.9
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.1
-      env: COMPOSER_FLAGS="" SYMFONY_VERSION="3.3.*"
-    - php: 7.1
-      env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.0.*"
-    - php: 7.2
-      env: COMPOSER_FLAGS="" SYMFONY_VERSION="3.3.*"
     - php: 7.2
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.0.*"
+    - php: 7.2
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.1.*"
+    - php: 7.2
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.2.*"
+    - php: 7.2
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.3.*"
 
 before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,17 @@ env:
 
 php:
     - 7.2
+    - 7.3
 
 matrix:
   include:
     - php: 7.2
-      env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.0.*"
-    - php: 7.2
-      env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.1.*"
-    - php: 7.2
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.2.*"
     - php: 7.2
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.3.*"
+    - php: 7.3
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.2.*"
+    - php: 7.3
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="4.3.*"
 
 before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,21 @@
         }
     ],
     "require": {
-        "php":                          "^5.5.9|^7.0",
-        "symfony/config":               "^3.3|^4.0",
-        "symfony/dependency-injection": "^3.3|^4.0",
-        "symfony/finder":               "^3.3|^4.0",
-        "symfony/framework-bundle":     "^3.3|^4.0",
-        "symfony/http-kernel":          "^3.3|^4.0"
+        "php":                          "^7.2",
+        "symfony/config":               "^4.0",
+        "symfony/dependency-injection": "^4.0",
+        "symfony/finder":               "^4.0",
+        "symfony/framework-bundle":     "^4.0",
+        "symfony/http-kernel":          "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit":     "^4.8.35|^6.0",
-        "symfony/twig-bundle": "^3.3|^4.0",
-        "symfony/yaml":        "^3.3|^4.0",
-        "twig/twig":           "^1.38.1|^2.7.2"
+        "phpunit/phpunit":     "^8.4.3",
+        "symfony/twig-bundle": "^4.0",
+        "symfony/yaml":        "^4.0",
+        "twig/twig":           "^2.12.1"
+    },
+    "suggest": {
+        "twig/twig": "Allows use of features in twig templates through the FeaturesExtension"
     },
     "minimum-stability": "dev",
     "prefer-stable":     true,

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     ],
     "require": {
         "php":                          "^7.2",
-        "symfony/config":               "^4.0",
-        "symfony/dependency-injection": "^4.0",
-        "symfony/finder":               "^4.0",
-        "symfony/framework-bundle":     "^4.0",
-        "symfony/http-kernel":          "^4.0"
+        "symfony/config":               "^4.2",
+        "symfony/dependency-injection": "^4.2",
+        "symfony/finder":               "^4.2",
+        "symfony/framework-bundle":     "^4.2",
+        "symfony/http-kernel":          "^4.2"
     },
     "require-dev": {
         "phpunit/phpunit":     "^8.4.3",
-        "symfony/twig-bundle": "^4.0",
-        "symfony/yaml":        "^4.0",
+        "symfony/twig-bundle": "^4.2",
+        "symfony/yaml":        "^4.2",
         "twig/twig":           "^2.12.1"
     },
     "suggest": {

--- a/src/DependencyInjection/Compiler/ConfigureFeaturesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ConfigureFeaturesCompilerPass.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Yannickl88\FeaturesBundle\Feature\DeprecatedFeature;
 use Yannickl88\FeaturesBundle\Feature\Feature;
 use Yannickl88\FeaturesBundle\Feature\FeatureContainer;
+use Yannickl88\FeaturesBundle\Feature\FeatureFactory;
 
 /**
  * Compiler pass which collects and create the feature tag services which can
@@ -25,10 +26,10 @@ final class ConfigureFeaturesCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        // configure the resolvers
+        // Configure the resolvers.
         $resolvers = $this->configureResolvers($container);
 
-        // configure the tags
+        // Configure the tags.
         $this->configureTags($container, $resolvers);
     }
 
@@ -38,7 +39,7 @@ final class ConfigureFeaturesCompilerPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @return string[]
      */
-    private function configureResolvers(ContainerBuilder $container)
+    private function configureResolvers(ContainerBuilder $container): array
     {
         $services  = $container->findTaggedServiceIds('features.resolver');
         $resolvers = ['chain' => true];
@@ -77,7 +78,7 @@ final class ConfigureFeaturesCompilerPass implements CompilerPassInterface
      * @param string[]         $configured_resolvers
      * @return string[]
      */
-    private function configureTags(ContainerBuilder $container, array $configured_resolvers)
+    private function configureTags(ContainerBuilder $container, array $configured_resolvers): array
     {
         $tags = $container->getParameter('features.tags');
         $all  = [];
@@ -96,7 +97,7 @@ final class ConfigureFeaturesCompilerPass implements CompilerPassInterface
 
             $definition = new Definition(Feature::class);
             $definition->setPublic(true);
-            $definition->setFactory([new Reference('features.factory'), 'createFeature']);
+            $definition->setFactory([new Reference(FeatureFactory::class), 'createFeature']);
             $definition->setArguments([$tag, $options]);
 
             $container->setDefinition('features.tag.' . $param_name, $definition);

--- a/src/DependencyInjection/Compiler/ReplaceFeaturesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ReplaceFeaturesCompilerPass.php
@@ -20,7 +20,7 @@ final class ReplaceFeaturesCompilerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $tags     = $container->getParameter('features.tags');
         $services = $container->findTaggedServiceIds('features.tag');

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,10 +21,9 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
-        $root    = $builder->root('features');
+        $builder = new TreeBuilder('features');
 
-        $root
+        $builder->getRootNode()
             ->children()
                 ->arrayNode('tags')
                     ->useAttributeAsKey('name')

--- a/src/DependencyInjection/FeaturesExtension.php
+++ b/src/DependencyInjection/FeaturesExtension.php
@@ -17,7 +17,7 @@ final class FeaturesExtension extends ConfigurableExtension
     /**
      * {@inheritdoc}
      */
-    protected function loadInternal(array $config, ContainerBuilder $container)
+    protected function loadInternal(array $config, ContainerBuilder $container): void
     {
         $tags = [];
         foreach ($config['tags'] as $name => $options) {

--- a/src/Feature/ChainFeatureResolver.php
+++ b/src/Feature/ChainFeatureResolver.php
@@ -6,14 +6,8 @@ namespace Yannickl88\FeaturesBundle\Feature;
  */
 class ChainFeatureResolver implements FeatureResolverInterface
 {
-    /**
-     * @var FeatureContainerInterface
-     */
     private $feature_container;
 
-    /**
-     * @param FeatureContainerInterface $feature_container
-     */
     public function __construct(FeatureContainerInterface $feature_container)
     {
         $this->feature_container = $feature_container;
@@ -22,7 +16,7 @@ class ChainFeatureResolver implements FeatureResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function isActive(array $options = [])
+    public function isActive(array $options = []): bool
     {
         $resolver = new Resolver();
 

--- a/src/Feature/DeprecatedFeature.php
+++ b/src/Feature/DeprecatedFeature.php
@@ -12,7 +12,7 @@ final class DeprecatedFeature implements Feature
     /**
      * {@inheritdoc}
      */
-    public function isActive()
+    public function isActive(): bool
     {
         @trigger_error(
             'Feature with no tag was used, please remove or configure the tag.',

--- a/src/Feature/Exception/FeatureNotFoundException.php
+++ b/src/Feature/Exception/FeatureNotFoundException.php
@@ -6,11 +6,7 @@ namespace Yannickl88\FeaturesBundle\Feature\Exception;
  */
 class FeatureNotFoundException extends \RuntimeException
 {
-    /**
-     * @param string $feature_tag
-     * @param mixed  $previous
-     */
-    public function __construct($feature_tag, $previous = null)
+    public function __construct(string $feature_tag, ?\Throwable $previous = null)
     {
         parent::__construct(sprintf('Feature "%s" was not found.', $feature_tag), null, $previous);
     }

--- a/src/Feature/Exception/ResolverNotFoundException.php
+++ b/src/Feature/Exception/ResolverNotFoundException.php
@@ -6,11 +6,7 @@ namespace Yannickl88\FeaturesBundle\Feature\Exception;
  */
 class ResolverNotFoundException extends \RuntimeException
 {
-    /**
-     * @param string $resolver_name
-     * @param mixed  $previous
-     */
-    public function __construct($resolver_name, $previous = null)
+    public function __construct(string $resolver_name, ?\Throwable $previous = null)
     {
         parent::__construct(sprintf(
             'Resolver "%s" was not found, did you forget to tag it with "features.resolver"?',

--- a/src/Feature/Feature.php
+++ b/src/Feature/Feature.php
@@ -10,8 +10,6 @@ interface Feature
 {
     /**
      * Check if the feature is active for the current request.
-     *
-     * @return bool
      */
-    public function isActive();
+    public function isActive(): bool;
 }

--- a/src/Feature/FeatureContainer.php
+++ b/src/Feature/FeatureContainer.php
@@ -12,19 +12,8 @@ use Yannickl88\FeaturesBundle\Feature\Exception\ResolverNotFoundException;
  */
 final class FeatureContainer implements FeatureContainerInterface
 {
-    /**
-     * @var ContainerInterface
-     */
     private $container;
-
-    /**
-     * @var string[]
-     */
     private $features;
-
-    /**
-     * @var FeatureResolverInterface[]
-     */
     private $resolvers;
 
     /**
@@ -42,7 +31,7 @@ final class FeatureContainer implements FeatureContainerInterface
     /**
      * {@inheritdoc}
      */
-    public function get($tag)
+    public function get($tag): Feature
     {
         if (!isset($this->features[$tag])) {
             throw new FeatureNotFoundException($tag);
@@ -54,9 +43,9 @@ final class FeatureContainer implements FeatureContainerInterface
     /**
      * {@inheritdoc}
      */
-    public function getResolver($name)
+    public function getResolver(string $name): FeatureResolverInterface
     {
-        if ($name == 'chain') { // special resolver
+        if ($name === 'chain') { // Special resolver.
             return new ChainFeatureResolver($this);
         }
 

--- a/src/Feature/FeatureContainerInterface.php
+++ b/src/Feature/FeatureContainerInterface.php
@@ -13,19 +13,15 @@ interface FeatureContainerInterface
      * Return a features by give name. If the feature was not found, an
      * exception is thrown.
      *
-     * @param string $tag
-     * @return Feature
      * @throws FeatureNotFoundException when feature was not found
      */
-    public function get($tag);
+    public function get(string $tag): Feature;
 
     /**
      * Return a resolver by given name. If the resolver was not found, an
      * exception is thrown.
      *
-     * @param string $name
-     * @return FeatureResolverInterface
      * @throws ResolverNotFoundException when resolver was not found
      */
-    public function getResolver($name);
+    public function getResolver(string $name): FeatureResolverInterface;
 }

--- a/src/Feature/FeatureFactory.php
+++ b/src/Feature/FeatureFactory.php
@@ -9,14 +9,8 @@ namespace Yannickl88\FeaturesBundle\Feature;
  */
 final class FeatureFactory
 {
-    /**
-     * @var FeatureContainer
-     */
     private $feature_container;
 
-    /**
-     * @param FeatureContainerInterface $feature_container
-     */
     public function __construct(FeatureContainerInterface $feature_container)
     {
         $this->feature_container = $feature_container;
@@ -31,12 +25,8 @@ final class FeatureFactory
      *     resolver2 => [<resolver specific options>],
      *     // etc.
      * ]
-     *
-     * @param string $feature_name
-     * @param array  $options
-     * @return Feature
      */
-    public function createFeature($feature_name, array $options = [])
+    public function createFeature(string $feature_name, array $options = []): Feature
     {
         $resolver = new Resolver();
 

--- a/src/Feature/FeatureResolverInterface.php
+++ b/src/Feature/FeatureResolverInterface.php
@@ -12,9 +12,6 @@ interface FeatureResolverInterface
 {
     /**
      * Check if this feature is active.
-     *
-     * @param array $options
-     * @return bool
      */
-    public function isActive(array $options = []);
+    public function isActive(array $options = []): bool;
 }

--- a/src/Feature/ResolvableFeature.php
+++ b/src/Feature/ResolvableFeature.php
@@ -9,21 +9,10 @@ namespace Yannickl88\FeaturesBundle\Feature;
  */
 final class ResolvableFeature implements Feature
 {
-    /**
-     * @var string
-     */
     private $name;
-
-    /**
-     * @var Resolver
-     */
     private $resolver;
 
-    /**
-     * @param string $name
-     * @param bool   $active
-     */
-    public function __construct($name, Resolver $resolver)
+    public function __construct(string $name, Resolver $resolver)
     {
         $this->name     = $name;
         $this->resolver = $resolver;
@@ -31,10 +20,8 @@ final class ResolvableFeature implements Feature
 
     /**
      * Return the name of the feature.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -42,7 +29,7 @@ final class ResolvableFeature implements Feature
     /**
      * {@inheritdoc}
      */
-    public function isActive()
+    public function isActive(): bool
     {
         return $this->resolver->resolve();
     }

--- a/src/Feature/Resolver.php
+++ b/src/Feature/Resolver.php
@@ -22,11 +22,7 @@ class Resolver
      */
     private $resolver_options = [];
 
-    /**
-     * @param FeatureResolverInterface $resolver
-     * @param array                    $options
-     */
-    public function addResolver(FeatureResolverInterface $resolver, array $options = [])
+    public function addResolver(FeatureResolverInterface $resolver, array $options = []): void
     {
         $key = spl_object_hash($resolver);
 
@@ -37,11 +33,9 @@ class Resolver
     /**
      * Resolve the final value.
      *
-     * @param string $strategy
-     * @return bool
      * @throws \InvalidArgumentException when strategy is unknown.
      */
-    public function resolve($strategy = self::STRATEGY_UNANIMOUS)
+    public function resolve(string $strategy = self::STRATEGY_UNANIMOUS): bool
     {
         switch ($strategy) {
             case self::STRATEGY_AFFIRMATIVE:
@@ -56,10 +50,8 @@ class Resolver
     /**
      * Resolve the feature where at least one voter needs to resolve true for
      * the feature to be active.
-     *
-     * @return bool
      */
-    private function resolveAffirmative()
+    private function resolveAffirmative(): bool
     {
         foreach ($this->resolvers as $key => $resolver) {
             if ($resolver->isActive($this->resolver_options[$key])) {
@@ -73,10 +65,8 @@ class Resolver
     /**
      * Resolve the feature where all the voters needs to resolve true for
      * the feature to be active.
-     *
-     * @return bool
      */
-    private function resolveUnanimous()
+    private function resolveUnanimous(): bool
     {
         foreach ($this->resolvers as $key => $resolver) {
             if (!$resolver->isActive($this->resolver_options[$key])) {

--- a/src/FeaturesBundle.php
+++ b/src/FeaturesBundle.php
@@ -15,7 +15,7 @@ final class FeaturesBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ConfigureFeaturesCompilerPass());
         $container->addCompilerPass(new ReplaceFeaturesCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING);

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,23 +1,16 @@
 services:
-    # old service names, deprecated
-    features.factory: '@Yannickl88\FeaturesBundle\Feature\FeatureFactory'
-    features.container:
-        alias: Yannickl88\FeaturesBundle\Feature\FeatureContainer
-        public: true
-    features.tag: '@Yannickl88\FeaturesBundle\Feature\DeprecatedFeature'
-    features.twig_extension: '@Yannickl88\FeaturesBundle\Twig\FeaturesExtension'
-
     Yannickl88\FeaturesBundle\Feature\FeatureFactory:
         - '@Yannickl88\FeaturesBundle\Feature\FeatureContainer'
 
+    Yannickl88\FeaturesBundle\Feature\FeatureContainerInterface: '@Yannickl88\FeaturesBundle\Feature\FeatureContainer'
     Yannickl88\FeaturesBundle\Feature\FeatureContainer:
         public: true
         arguments:
-            - "@service_container"
-            - [] # replaced by extension
-            - [] # replaced by extension
+            - '@service_container'
+            - [] # Replaced by extension.
+            - [] # Replaced by extension.
 
-    # alias to allow autowiring the deprecated feature by default
+    # Alias to allow autowiring the deprecated feature by default.
     Yannickl88\FeaturesBundle\Feature\Feature: '@Yannickl88\FeaturesBundle\Feature\DeprecatedFeature'
     Yannickl88\FeaturesBundle\Feature\DeprecatedFeature: ~
 

--- a/src/Twig/FeaturesExtension.php
+++ b/src/Twig/FeaturesExtension.php
@@ -10,14 +10,8 @@ use Yannickl88\FeaturesBundle\Feature\FeatureContainerInterface;
  */
 class FeaturesExtension extends AbstractExtension
 {
-    /**
-     * @var FeatureContainerInterface
-     */
     private $container;
 
-    /**
-     * @param FeatureContainerInterface $container
-     */
     public function __construct(FeatureContainerInterface $container)
     {
         $this->container = $container;
@@ -26,7 +20,7 @@ class FeaturesExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('feature', function ($tag) {
@@ -38,7 +32,7 @@ class FeaturesExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'features_extension';
     }

--- a/test/DependencyInjection/Compiler/ConfigureFeaturesCompilerPassTest.php
+++ b/test/DependencyInjection/Compiler/ConfigureFeaturesCompilerPassTest.php
@@ -4,6 +4,7 @@ namespace Yannickl88\FeaturesBundle\DependencyInjection\Compiler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 use Yannickl88\FeaturesBundle\Feature\FeatureContainer;
 use Yannickl88\FeaturesBundle\Feature\FeatureFactory;
@@ -19,12 +20,12 @@ class ConfigureFeaturesCompilerPassTest extends TestCase
      */
     private $configure_features_compiler_pass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configure_features_compiler_pass = new ConfigureFeaturesCompilerPass();
     }
 
-    public function testProcess()
+    public function testProcess(): void
     {
         $container = new ContainerBuilder();
 
@@ -64,11 +65,7 @@ class ConfigureFeaturesCompilerPassTest extends TestCase
         self::assertEquals('features.tag', $target->getArgument(1)->__toString());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The value for "config-key" is missing in the tag "features.tag" for service "test.resolver".
-     */
-    public function testProcessMissingConfigKey()
+    public function testProcessMissingConfigKey(): void
     {
         $container = new ContainerBuilder();
 
@@ -84,14 +81,14 @@ class ConfigureFeaturesCompilerPassTest extends TestCase
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The value for "config-key" is missing in the tag "features.tag" for service "test.resolver".'
+        );
         $this->configure_features_compiler_pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The config-key "resolver" is already configured by resolver "test.resolver1".
-     */
-    public function testProcessDuplicateConfigKey()
+    public function testProcessDuplicateConfigKey(): void
     {
         $container = new ContainerBuilder();
 
@@ -111,14 +108,14 @@ class ConfigureFeaturesCompilerPassTest extends TestCase
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The config-key "resolver" is already configured by resolver "test.resolver1".'
+        );
         $this->configure_features_compiler_pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Unknown resolver(s) "missing" configured for feature tag "foo".
-     */
-    public function testProcessMissingResolver()
+    public function testProcessMissingResolver(): void
     {
         $container = new ContainerBuilder();
 
@@ -138,6 +135,10 @@ class ConfigureFeaturesCompilerPassTest extends TestCase
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['missing' => []]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Unknown resolver(s) "missing" configured for feature tag "foo".'
+        );
         $this->configure_features_compiler_pass->process($container);
     }
 }

--- a/test/DependencyInjection/Compiler/ReplaceFeaturesCompilerPassTest.php
+++ b/test/DependencyInjection/Compiler/ReplaceFeaturesCompilerPassTest.php
@@ -4,6 +4,7 @@ namespace Yannickl88\FeaturesBundle\DependencyInjection\Compiler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 use Yannickl88\FeaturesBundle\Feature\FeatureContainer;
 use Yannickl88\FeaturesBundle\Feature\FeatureFactory;
@@ -19,12 +20,12 @@ class ReplaceFeaturesCompilerPassTest extends TestCase
      */
     private $features_compiler_pass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->features_compiler_pass = new ReplaceFeaturesCompilerPass();
     }
 
-    public function testProcess()
+    public function testProcess(): void
     {
         $container = new ContainerBuilder();
 
@@ -61,11 +62,7 @@ class ReplaceFeaturesCompilerPassTest extends TestCase
         self::assertEquals('features.tag.foo', $target->getArgument(1)->__toString());
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The value for "tag" is missing in the tag "features.tag" for service "test.service".
-     */
-    public function testProcessMissingTag()
+    public function testProcessMissingTag(): void
     {
         $container = new ContainerBuilder();
 
@@ -92,14 +89,14 @@ class ReplaceFeaturesCompilerPassTest extends TestCase
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The value for "tag" is missing in the tag "features.tag" for service "test.service".'
+        );
         $this->features_compiler_pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Multiple "features.tag" tags found for service "test.service", only one is allowed per service.
-     */
-    public function testProcessMultipleTags()
+    public function testProcessMultipleTags(): void
     {
         $container = new ContainerBuilder();
 
@@ -127,14 +124,14 @@ class ReplaceFeaturesCompilerPassTest extends TestCase
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Multiple "features.tag" tags found for service "test.service", only one is allowed per service.'
+        );
         $this->features_compiler_pass->process($container);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Unknown tag "bar" used in the "feature.tag" of service "test.service".
-     */
-    public function testProcessUnknownTag()
+    public function testProcessUnknownTag(): void
     {
         $container = new ContainerBuilder();
 
@@ -161,6 +158,10 @@ class ReplaceFeaturesCompilerPassTest extends TestCase
         $container->setParameter('features.tags', ['foo' => 'foo']);
         $container->setParameter('features.tags.foo.options', ['resolver' => []]);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Unknown tag "bar" used in the "feature.tag" of service "test.service".'
+        );
         $this->features_compiler_pass->process($container);
     }
 }

--- a/test/DependencyInjection/FeaturesExtensionTest.php
+++ b/test/DependencyInjection/FeaturesExtensionTest.php
@@ -15,7 +15,7 @@ class FeaturesExtensionTest extends TestCase
      */
     private $features_extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->features_extension = new FeaturesExtension();
     }

--- a/test/Feature/ChainFeatureResolverTest.php
+++ b/test/Feature/ChainFeatureResolverTest.php
@@ -16,7 +16,7 @@ class ChainFeatureResolverTest extends TestCase
      */
     private $chain_feature_resolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->feature_container = $this->prophesize(FeatureContainerInterface::class);
 
@@ -25,7 +25,7 @@ class ChainFeatureResolverTest extends TestCase
         );
     }
 
-    public function testIsActive()
+    public function testIsActive(): void
     {
         $resolver1 = $this->prophesize(FeatureResolverInterface::class);
         $resolver2 = $this->prophesize(FeatureResolverInterface::class);

--- a/test/Feature/DeprecatedFeatureTest.php
+++ b/test/Feature/DeprecatedFeatureTest.php
@@ -13,17 +13,17 @@ class DeprecatedFeatureTest extends TestCase
      */
     private $deprecated_feature;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->deprecated_feature = new DeprecatedFeature();
     }
 
-    public function testIsActive()
+    public function testIsActive(): void
     {
         self::assertTrue($this->deprecated_feature->isActive());
     }
 
-    public function testIsActiveNotice()
+    public function testIsActiveNotice(): void
     {
         set_error_handler(function ($errno, $errstr) {
             self::assertEquals('Feature with no tag was used, please remove or configure the tag.', $errstr);

--- a/test/Feature/Exception/FeatureNotFoundExceptionTest.php
+++ b/test/Feature/Exception/FeatureNotFoundExceptionTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FeatureNotFoundExceptionTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $e = new FeatureNotFoundException('foo');
 

--- a/test/Feature/Exception/ResolverNotFoundExceptionTest.php
+++ b/test/Feature/Exception/ResolverNotFoundExceptionTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ResolverNotFoundExceptionTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $e = new ResolverNotFoundException('foo');
 

--- a/test/Feature/FeatureContainerTest.php
+++ b/test/Feature/FeatureContainerTest.php
@@ -3,6 +3,8 @@ namespace Yannickl88\FeaturesBundle\Feature;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Yannickl88\FeaturesBundle\Feature\Exception\FeatureNotFoundException;
+use Yannickl88\FeaturesBundle\Feature\Exception\ResolverNotFoundException;
 
 /**
  * @covers Yannickl88\FeaturesBundle\Feature\FeatureContainer
@@ -20,7 +22,7 @@ class FeatureContainerTest extends TestCase
      */
     private $feature_container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
         $this->feature   = $this->prophesize(Feature::class);
@@ -40,36 +42,32 @@ class FeatureContainerTest extends TestCase
         );
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $this->container->get('features.tag.test')->willReturn($this->feature);
 
         self::assertSame($this->feature->reveal(), $this->feature_container->get('test'));
     }
 
-    /**
-     * @expectedException Yannickl88\FeaturesBundle\Feature\Exception\FeatureNotFoundException
-     */
-    public function testGetUnknownFeature()
+    public function testGetUnknownFeature(): void
     {
+        $this->expectException(FeatureNotFoundException::class);
         $this->feature_container->get('phpunit');
     }
 
-    public function testGetResolver()
+    public function testGetResolver(): void
     {
         self::assertEquals($this->resolver->reveal(), $this->feature_container->getResolver('test'));
     }
 
-    public function testGetResolverChain()
+    public function testGetResolverChain(): void
     {
         self::assertInstanceOf(ChainFeatureResolver::class, $this->feature_container->getResolver('chain'));
     }
 
-    /**
-     * @expectedException Yannickl88\FeaturesBundle\Feature\Exception\ResolverNotFoundException
-     */
-    public function testCreateFeatureMissingResolver()
+    public function testCreateFeatureMissingResolver(): void
     {
+        $this->expectException(ResolverNotFoundException::class);
         $this->feature_container->getResolver('foz');
     }
 }

--- a/test/Feature/FeatureFactoryTest.php
+++ b/test/Feature/FeatureFactoryTest.php
@@ -15,7 +15,7 @@ class FeatureFactoryTest extends TestCase
      */
     private $feature_factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->feature_container = $this->prophesize(FeatureContainerInterface::class);
 
@@ -24,7 +24,7 @@ class FeatureFactoryTest extends TestCase
         );
     }
 
-    public function testCreateFeature()
+    public function testCreateFeature(): void
     {
         $resolver1 = $this->prophesize(FeatureResolverInterface::class);
         $resolver2 = $this->prophesize(FeatureResolverInterface::class);
@@ -35,6 +35,6 @@ class FeatureFactoryTest extends TestCase
         $feature = $this->feature_factory->createFeature('foobar', ['foo' => [], 'bar' => []]);
 
         self::assertInstanceOf(ResolvableFeature::class, $feature);
-        self::assertEquals('foobar', $feature->getName());
+        self::assertSame('foobar', $feature->getName());
     }
 }

--- a/test/Feature/ResolvableFeatureTest.php
+++ b/test/Feature/ResolvableFeatureTest.php
@@ -17,7 +17,7 @@ class ResolvableFeatureTest extends TestCase
      */
     private $resolvable_feature;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->name     = 'foo';
         $this->resolver = $this->prophesize(Resolver::class);
@@ -28,22 +28,22 @@ class ResolvableFeatureTest extends TestCase
         );
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
-        self::assertEquals($this->name, $this->resolvable_feature->getName());
+        self::assertSame($this->name, $this->resolvable_feature->getName());
     }
 
     /**
      * @dataProvider resolverProvider
      */
-    public function testisActive($expected_active, $resolver_active)
+    public function testIsActive(bool $expected_active, bool $resolver_active): void
     {
         $this->resolver->resolve()->willReturn($resolver_active);
 
-        self::assertEquals($expected_active, $this->resolvable_feature->isActive());
+        self::assertSame($expected_active, $this->resolvable_feature->isActive());
     }
 
-    public function resolverProvider()
+    public function resolverProvider(): iterable
     {
         return [
             [true, true],

--- a/test/Feature/ResolverTest.php
+++ b/test/Feature/ResolverTest.php
@@ -13,12 +13,12 @@ class ResolverTest extends TestCase
      */
     private $resolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->resolver = new Resolver();
     }
 
-    public function testAddResolver()
+    public function testAddResolver(): void
     {
         $feature_resolver = $this->prophesize(FeatureResolverInterface::class);
 
@@ -28,7 +28,7 @@ class ResolverTest extends TestCase
         self::assertTrue($this->resolver->resolve());
     }
 
-    public function testResolveUnanimous()
+    public function testResolveUnanimous(): void
     {
         $feature_resolver1 = $this->prophesize(FeatureResolverInterface::class);
         $feature_resolver2 = $this->prophesize(FeatureResolverInterface::class);
@@ -42,7 +42,7 @@ class ResolverTest extends TestCase
         self::assertFalse($this->resolver->resolve(Resolver::STRATEGY_UNANIMOUS));
     }
 
-    public function testResolveAffirmative()
+    public function testResolveAffirmative(): void
     {
         $feature_resolver1 = $this->prophesize(FeatureResolverInterface::class);
         $feature_resolver2 = $this->prophesize(FeatureResolverInterface::class);
@@ -56,7 +56,7 @@ class ResolverTest extends TestCase
         self::assertTrue($this->resolver->resolve(Resolver::STRATEGY_AFFIRMATIVE));
     }
 
-    public function testResolveAffirmativeNoDecision()
+    public function testResolveAffirmativeNoDecision(): void
     {
         $feature_resolver1 = $this->prophesize(FeatureResolverInterface::class);
         $feature_resolver2 = $this->prophesize(FeatureResolverInterface::class);
@@ -70,15 +70,10 @@ class ResolverTest extends TestCase
         self::assertFalse($this->resolver->resolve(Resolver::STRATEGY_AFFIRMATIVE));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The strategy "henk" is not supported.
-     */
-    public function testResolveUnknown()
+    public function testResolveUnknown(): void
     {
-        $this->resolver->addResolver($this->prophesize(FeatureResolverInterface::class)->reveal(), ['henk']);
-        $this->resolver->addResolver($this->prophesize(FeatureResolverInterface::class)->reveal(), ['hans']);
-
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The strategy "henk" is not supported.');
         self::assertFalse($this->resolver->resolve('henk'));
     }
 }

--- a/test/FeaturesBundleTest.php
+++ b/test/FeaturesBundleTest.php
@@ -16,12 +16,12 @@ class FeaturesBundleTest extends TestCase
      */
     private $features_bundle;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->features_bundle = new FeaturesBundle();
     }
 
-    public function testBuild()
+    public function testBuild(): void
     {
         $container = new ContainerBuilder();
 

--- a/test/Functional/ConfigurationTest.php
+++ b/test/Functional/ConfigurationTest.php
@@ -3,20 +3,20 @@ namespace Yannickl88\FeaturesBundle;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Yannickl88\FeaturesBundle\Feature\DeprecatedFeature;
+use Yannickl88\FeaturesBundle\Feature\FeatureContainer;
 use Yannickl88\FeaturesBundle\Functional\Fixtures\TestClass;
-use Yannickl88\FeaturesBundle\Functional\Fixtures\TestKernel;
 
 class ConfigurationTest extends KernelTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         static::bootKernel();
     }
 
-    public function testFeatures()
+    public function testFeatures(): void
     {
         $container = static::$kernel->getContainer();
-        $features  = $container->get('features.container');
+        $features  = $container->get(FeatureContainer::class);
 
         // check if all the feature services are correcly configured
         $feature_test  = $features->get('test');
@@ -45,14 +45,14 @@ class ConfigurationTest extends KernelTestCase
         self::assertTrue($feature_test8->isActive());
         self::assertEquals('test-with-strange_name', $feature_test8->getName());
 
-        // check if all the feature services are correcly injected
+        // Check if all the feature services are correctly injected.
         self::assertEquals($feature_test, $container->get(TestClass::class)->feature);
         self::assertEquals($feature_test2, $container->get('app.test2')->feature);
         self::assertEquals($feature_test8, $container->get('app.test3')->feature);
         self::assertEquals(new DeprecatedFeature(), $container->get('app.test_no_tag')->feature);
     }
 
-    public function testTwigFeature()
+    public function testTwigFeature(): void
     {
         $container = static::$kernel->getContainer();
 

--- a/test/Functional/Fixtures/BarFeatureResolver.php
+++ b/test/Functional/Fixtures/BarFeatureResolver.php
@@ -5,8 +5,8 @@ use Yannickl88\FeaturesBundle\Feature\FeatureResolverInterface;
 
 class BarFeatureResolver implements FeatureResolverInterface
 {
-    public function isActive(array $options = [])
+    public function isActive(array $options = []): bool
     {
-        return in_array(13, $options);
+        return in_array(13, $options, true);
     }
 }

--- a/test/Functional/Fixtures/Dummy.php
+++ b/test/Functional/Fixtures/Dummy.php
@@ -1,7 +1,5 @@
 <?php
-
 namespace Yannickl88\FeaturesBundle\Functional\Fixtures;
-
 
 class Dummy
 {

--- a/test/Functional/Fixtures/FooFeatureResolver.php
+++ b/test/Functional/Fixtures/FooFeatureResolver.php
@@ -5,8 +5,8 @@ use Yannickl88\FeaturesBundle\Feature\FeatureResolverInterface;
 
 class FooFeatureResolver implements FeatureResolverInterface
 {
-    public function isActive(array $options = [])
+    public function isActive(array $options = []): bool
     {
-        return in_array(42, $options);
+        return in_array(42, $options, true);
     }
 }

--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -6,26 +6,26 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class TestKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): array
     {
-        return array(
+        return [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \Yannickl88\FeaturesBundle\FeaturesBundle(),
-        );
+        ];
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return __DIR__ . '/../../../var/log';
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return __DIR__ . '/../../../var/cache';
     }

--- a/test/Functional/Fixtures/config/config.yml
+++ b/test/Functional/Fixtures/config/config.yml
@@ -24,7 +24,7 @@ services:
         class: Yannickl88\FeaturesBundle\Functional\Fixtures\TestClass
         public: true
         arguments:
-            - "@features.tag"
+            - '@features.tag'
         tags:
             - { name: features.tag, tag: test2 }
 

--- a/test/Twig/FeaturesExtensionTest.php
+++ b/test/Twig/FeaturesExtensionTest.php
@@ -18,14 +18,14 @@ class FeaturesExtensionTest extends TestCase
      */
     private $features_extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->feature_container = $this->prophesize(FeatureContainerInterface::class);
 
         $this->features_extension = new FeaturesExtension($this->feature_container->reveal());
     }
 
-    public function testGetFunctions()
+    public function testGetFunctions(): void
     {
         /* @var $functions TwigFunction[] */
         $functions = $this->features_extension->getFunctions();
@@ -35,12 +35,12 @@ class FeaturesExtensionTest extends TestCase
 
         $this->feature_container->get('foo')->willReturn($feature);
 
-        self::assertEquals('feature', $functions[0]->getName());
-        self::assertEquals(true, call_user_func($functions[0]->getCallable(), 'foo'));
+        self::assertSame('feature', $functions[0]->getName());
+        self::assertSame(true, call_user_func($functions[0]->getCallable(), 'foo'));
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
-        self::assertEquals('features_extension', $this->features_extension->getName());
+        self::assertSame('features_extension', $this->features_extension->getName());
     }
 }


### PR DESCRIPTION
Only support;
- Php 7.2 and up (including strict types)
- Symfony 4.0 and up.